### PR TITLE
handling product owned IAP billing response, closes#8

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -14,8 +14,8 @@ android {
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 23
-        versionCode 9
-        versionName "1.2.6"
+        versionCode 10
+        versionName "1.2.7"
     }
 
     lintOptions {

--- a/library/src/main/java/com/android/vending/billing/IabHelper.java
+++ b/library/src/main/java/com/android/vending/billing/IabHelper.java
@@ -526,7 +526,11 @@ public class IabHelper {
         } else {
             logError("Purchase failed. Result code: " + Integer.toString(resultCode)
                     + ". Response: " + getResponseDesc(responseCode));
-            result = new IabResult(IABHELPER_UNKNOWN_PURCHASE_RESPONSE, "Unknown purchase response.");
+            if (responseCode == BILLING_RESPONSE_RESULT_ITEM_ALREADY_OWNED) {
+                result = new IabResult(BILLING_RESPONSE_RESULT_ITEM_ALREADY_OWNED, "Success");
+            } else {
+                result = new IabResult(IABHELPER_UNKNOWN_PURCHASE_RESPONSE, "Unknown purchase response.");
+            }
             if (mPurchaseListener != null) mPurchaseListener.onIabPurchaseFinished(result, null);
         }
         return true;

--- a/library/src/main/java/com/billing/google/GoogleBillingListener.java
+++ b/library/src/main/java/com/billing/google/GoogleBillingListener.java
@@ -27,13 +27,20 @@ public class GoogleBillingListener implements IabHelper.OnIabSetupFinishedListen
     @Override
     public void onIabPurchaseFinished(IabResult result, Purchase info) {
         try {
-            if (result != null && info != null && result.isSuccess()) {
+            if (result != null && info != null &&
+                    (result.isSuccess() || result.getResponse() == IabHelper.BILLING_RESPONSE_RESULT_ITEM_ALREADY_OWNED)) {
                 //We assume that any problems will have become obvious through the Play store, so no need to do anything
                 //if the purchase has failed.
                 if (info.getItemType().equals(IabHelper.ITEM_TYPE_INAPP)) {
                     googleBillingService.productOwned(info.getSku(), false);
                 } else {
                     googleBillingService.subscriptionOwned(info.getSku(), false);
+                }
+            } else if (result != null && result.getResponse() == IabHelper.BILLING_RESPONSE_RESULT_ITEM_ALREADY_OWNED) {
+                if (googleBillingService.isProductPurchaseRequested()) {
+                    googleBillingService.productOwned(googleBillingService.getLastRequestedSku(), false);
+                } else {
+                    googleBillingService.subscriptionOwned(googleBillingService.getLastRequestedSku(), false);
                 }
             }
         } catch (Exception ex) {

--- a/library/src/main/java/com/billing/google/GoogleBillingService.java
+++ b/library/src/main/java/com/billing/google/GoogleBillingService.java
@@ -16,6 +16,8 @@ public class GoogleBillingService extends BillingService {
     private IabHelper iap;
     public List<String> iapkeys;
     private GoogleBillingListener googleBillingListener;
+    private String lastRequestedSku;
+    private boolean productPurchaseRequested;
 
     public GoogleBillingService(Context context, List<String> iapkeys) {
         super();
@@ -58,8 +60,11 @@ public class GoogleBillingService extends BillingService {
     @Override
     public void buy(Activity activity, String sku, int id) {
         try {
-            if (iap != null)
+            if (iap != null) {
+                lastRequestedSku = sku;
+                productPurchaseRequested = true;
                 iap.launchPurchaseFlow(activity, sku, id, googleBillingListener);
+            }
         } catch (Exception ex) {
             ex.printStackTrace();
         }
@@ -68,8 +73,11 @@ public class GoogleBillingService extends BillingService {
     @Override
     public void subscribe(Activity activity, String sku, int id) {
         try {
-            if (iap != null)
+            if (iap != null) {
+                lastRequestedSku = sku;
+                productPurchaseRequested = false;
                 iap.launchSubscriptionPurchaseFlow(activity, sku, id, googleBillingListener);
+            }
         } catch (Exception ex) {
             ex.printStackTrace();
         }
@@ -99,5 +107,13 @@ public class GoogleBillingService extends BillingService {
     public void close() {
         iap.dispose();
         super.close();
+    }
+
+    public String getLastRequestedSku() {
+        return lastRequestedSku;
+    }
+
+    public boolean isProductPurchaseRequested() {
+        return productPurchaseRequested;
     }
 }


### PR DESCRIPTION
Attempt to handle ALREADY_OWNED response. Had to cache requested SKU and product type, because IAP billing doesn't retrurn product info upon ALREADY_OWNED response. 
