### PR TITLE
Add pagination for Amazon update

### DIFF
--- a/library/src/amazon/java/com/billing/AmazonBillingListener.kt
+++ b/library/src/amazon/java/com/billing/AmazonBillingListener.kt
@@ -89,6 +89,11 @@ internal class AmazonBillingListener(private val amazonBillingService: BillingSe
                     }
                 }
             }
+            if (response.hasMore()) {
+                // if user has more then 100 purchases, then we need to support pagination to retrieve all of them.
+                // described here https://developer.amazon.com/docs/in-app-purchasing/iap-implement-iap.html#4-implement-getpurchaseupdates-method
+                PurchasingService.getPurchaseUpdates(false)
+            }
         }
     }
 

--- a/library/src/amazon/java/com/billing/AmazonBillingListener.kt
+++ b/library/src/amazon/java/com/billing/AmazonBillingListener.kt
@@ -90,7 +90,7 @@ internal class AmazonBillingListener(private val amazonBillingService: BillingSe
                 }
             }
             if (response.hasMore()) {
-                // if user has more then 100 purchases, then we need to support pagination to retrieve all of them.
+                // if user has more than 100 purchases, then we need to support pagination to retrieve all of them.
                 // described here https://developer.amazon.com/docs/in-app-purchasing/iap-implement-iap.html#4-implement-getpurchaseupdates-method
                 PurchasingService.getPurchaseUpdates(false)
             }


### PR DESCRIPTION
 If user has more than 100 purchases, then we need to support pagination to retrieve all of them.

Described here:
 https://developer.amazon.com/docs/in-app-purchasing/iap-implement-iap.html#4-implement-getpurchaseupdates-method